### PR TITLE
Fixed npm install command syntax

### DIFF
--- a/tutorials/how-to-create-an-nft/README.md
+++ b/tutorials/how-to-create-an-nft/README.md
@@ -265,7 +265,7 @@ Hardhat makes it super easy to integrate [Plugins](https://hardhat.org/plugins/)
 In your project directory type:
 
 ```text
-npm install --save-dev @nomiclabs/hardhat-ethers 'ethers@^5.0.0'
+npm install --save-dev @nomiclabs/hardhat-ethers "ethers@^5.0.0"
 ```
 
 We’ll also require ethers in our `hardhat.config.js` in the next step.


### PR DESCRIPTION
A user on Windows 10 reported the command was not working properly with single quotes, so changing to use double quotes. This also matches the instructions in tutorials/hello-world-smart-contract/README.md