### PR TITLE
Added link to issues page

### DIFF
--- a/introduction/contributing-to-docs.md
+++ b/introduction/contributing-to-docs.md
@@ -45,7 +45,7 @@ If you do not have a specific contribution in mind but are generally interested 
   * Raise issues for other contributors to address
 
 * **Fix an existing issue**
-  * Navigate to &lt;issues link&gt; and pick off one of the existing issues to fix!
+  * Navigate to the [issues page on Github](https://github.com/alchemyplatform/alchemy-docs/issues) and pick off one of the existing issues to fix!
 
 ## Contribute Alchemy Docs: <a id="contribute-alchemy-docs"></a>
 


### PR DESCRIPTION
Hi, I noticed the issues link in `contributing-to-docs.md` was not actually a link, so I added it