### PR TITLE
Update using-notify.md

### DIFF
--- a/guides/using-notify.md
+++ b/guides/using-notify.md
@@ -321,7 +321,7 @@ function isValidSignature(request) {
     const signature = headers['x-alchemy-signature']; // Lowercase for NodeJS
     const body = request.body;    
     const hmac = crypto.createHmac('sha256', token) // Create a HMAC SHA256 hash using the auth token
-    hmac.update(body, 'utf8') // Update the token hash with the request body using utf8
+    hmac.update(JSON.stringify(body), 'utf8') // Update the token hash with the request body using utf8
     const digest = hmac.digest('hex');     
     return (signature === digest); // If signature equals your computed hash, return true
 }


### PR DESCRIPTION
`hmac.update` takes a string, not an object, so we have to stringify the body before we use it.

Related error:
```
error - TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of Object
    at Hmac.update (internal/crypto/hash.js:84:11)
```