### PR TITLE
Fix missing V2 urls

### DIFF
--- a/introduction/getting-started.md
+++ b/introduction/getting-started.md
@@ -139,7 +139,7 @@ Hint: You should ultimately replace `<api-key>` with your Alchemy HTTP API key.
 ```javascript
 async function main() {
  const { createAlchemyWeb3 } = require("@alch/alchemy-web3");
- const web3 = createAlchemyWeb3("https://eth-mainnet.alchemyapi.io/<api-key>");
+ const web3 = createAlchemyWeb3("https://eth-mainnet.alchemyapi.io/v2/<api-key>");
  const blockNumber = await web3.eth.getBlockNumber();
  console.log("The latest block number is " + blockNumber);
 }

--- a/tutorials/simple-web3-script.md
+++ b/tutorials/simple-web3-script.md
@@ -33,7 +33,7 @@ You should ultimately replace `<api-key>` with your Alchemy HTTP API key.&#x20;
 ```javascript
 async function main() {
  const { createAlchemyWeb3 } = require("@alch/alchemy-web3");
- const web3 = createAlchemyWeb3("https://eth-mainnet.alchemyapi.io/<api-key>");
+ const web3 = createAlchemyWeb3("https://eth-mainnet.alchemyapi.io/v2/<api-key>");
  const blockNumber = await web3.eth.getBlockNumber();
  console.log("The latest block number is " + blockNumber);
 }


### PR DESCRIPTION
A couple parts of the tutorial were missing `v2` in the URL. Updated.