### PR TITLE
Changing NFT tutorial to be compatible with new Solidity 0.8.0 compiler version

### DIFF
--- a/tutorials/how-to-create-an-nft/README.md
+++ b/tutorials/how-to-create-an-nft/README.md
@@ -173,14 +173,14 @@ Open up the my-nft project in your favorite editor (we like [VSCode](https://cod
 ```
 //Contract based on https://docs.openzeppelin.com/contracts/3.x/erc721
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.7.3;
+pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 import "@openzeppelin/contracts/utils/Counters.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 
-contract MyNFT is ERC721, Ownable {
+contract MyNFT is ERC721URIStorage, Ownable {
     using Counters for Counters.Counter;
     Counters.Counter private _tokenIds;
 
@@ -203,13 +203,13 @@ contract MyNFT is ERC721, Ownable {
 
 1. Because we are inheriting classes from the OpenZepplin contracts library, in your command line run the following to install the library into our folder:
 
-`npm install @openzeppelin/contracts@3.1.0-solc-0.7`
+`npm install @openzeppelin/contracts`
 
 So, what does this code _do_ exactly? Let's break it down, line by line.
 
 In lines 5-7, our code inherits three [OpenZepplin](https://openzeppelin.com) smart contract classes:
 
-* `@openzeppelin/contracts/token/ERC721/ERC721.sol`contains the implementation of the ERC721 standard, which our NFT smart contract will inherit. (To be a valid NFT, your smart contract must implement all the methods of the ERC721 standard.) To learn more about the inherited ERC721 functions, check out the interface definition [here](https://eips.ethereum.org/EIPS/eip-721).
+* `@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol`contains the implementation of the ERC721 standard (along with a few additional NFT metadata tracking helper methods), which our NFT smart contract will inherit. (To be a valid NFT, your smart contract must implement all the methods of the ERC721 standard.) To learn more about the inherited ERC721 functions, check out the interface definition [here](https://eips.ethereum.org/EIPS/eip-721).
 * `@openzeppelin/contracts/utils/Counters.sol`provides counters that can only be incremented or decremented by one. Our smart contract uses a counter to keep track of the total number of NFTs minted and set the unique ID to our new NFT. Each NFT minted using a smart contract must be assigned a unique ID—here our unique ID is just determined by the total number of NFTs in existance. For example, the first NFT we mint with our smart contract has an ID of "1," our second NFT has an ID of "2," etc.
 * `@openzeppelin/contracts/access/Ownable.sol` sets up [access control](https://docs.openzeppelin.com/contracts/3.x/access-control) on our smart contract, so only the owner of the smart contract (you) can mint NFTs. Note, including access control is entirely a preference. If you'd like anyone to be able to mint an NFT using your smart contract, remove the word `Ownable` on line 10 and `onlyOwner` on line 17.
 
@@ -286,7 +286,7 @@ require('dotenv').config();
 require("@nomiclabs/hardhat-ethers");
 const { API_URL, PRIVATE_KEY } = process.env;
 module.exports = {
-   solidity: "0.7.3",
+   solidity: "0.8.1",
    defaultNetwork: "ropsten",
    networks: {
       hardhat: {},

--- a/tutorials/how-to-create-an-nft/README.md
+++ b/tutorials/how-to-create-an-nft/README.md
@@ -184,7 +184,7 @@ contract MyNFT is ERC721URIStorage, Ownable {
     using Counters for Counters.Counter;
     Counters.Counter private _tokenIds;
 
-    constructor() public ERC721("MyNFT", "NFT") {}
+    constructor() ERC721("MyNFT", "NFT") {}
 
     function mintNFT(address recipient, string memory tokenURI)
         public onlyOwner


### PR DESCRIPTION
What up y'all — it's me again!! Missing you guys. Made some updates to the NFT tutorial to be compatible with the new Solidity 0.8.0 compiler version. I ran into this issue while developing myself. Check out the PR @thatguyintech @kurushdubash @dphilipson @pileofscraps @deric-alchemy!!

So here's the issue — with the new Solidity compiler version [0.8.0](https://blog.soliditylang.org/2022/02/16/solidity-0.8.12-release-announcement/) and all the minor changes after that, OpenZeppelin's npm package from the Alchemy tutorial (`@openzeppelin/contracts@3.1.0-solc-0.7`) was out of date. So, what do we want to do?

We want to download the new npm package using `npm install @openzeppelin/contracts` instead. This will update all of our pragma headers from `pragma solidity ^0.7.0;` (out of date) to `pragma solidity ^0.8.0;`, where the compiler versions are up-to-date!!

All is good, right? No! Take a look at the Solidity code below from our [How to Create an NFT tutorial](https://docs.alchemy.com/alchemy/tutorials/how-to-create-an-nft):

```java
//Contract based on https://docs.openzeppelin.com/contracts/3.x/erc721
// SPDX-License-Identifier: MIT
pragma solidity ^0.7.3;

import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
import "@openzeppelin/contracts/utils/Counters.sol";
import "@openzeppelin/contracts/access/Ownable.sol";


contract MyNFT is ERC721, Ownable {
    using Counters for Counters.Counter;
    Counters.Counter private _tokenIds;

    constructor() public ERC721("MyNFT", "NFT") {}

    function mintNFT(address recipient, string memory tokenURI)
        public onlyOwner
        returns (uint256)
    {
        _tokenIds.increment();

        uint256 newItemId = _tokenIds.current();
        _mint(recipient, newItemId);
        _setTokenURI(newItemId, tokenURI);

        return newItemId;
    }
}
```

Notice how the `_setTokenURI` function is called to set the URI in the new NFT, which updates the mapping `_tokenURIs` allowing to retrieve its content through `function tokenURI(uint256 tokenId)`. However, OpenZeppelin decided to deprecate this function in their new 0.8.0-updated library (wtf?) in the name of flexibility for developers to define their own functions. See [here](https://forum.openzeppelin.com/t/function-settokenuri-in-erc721-is-gone-with-pragma-0-8-0/5978) for more info. This meant that developers had to implement the `mapping (uint256 => string) private _tokenURIs;` _tokenURIs hashmap themselves :man_facepalming: 

However, OpenZeppelin finally came to their senses and updated their library to include the `_setTokenURI` function, except instead of being in the `"@openzeppelin/contracts/token/ERC721/ERC721.sol"` filepath, it's now sitting in an extension in an extension resource designated by `"@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol"`.  See [here](https://forum.openzeppelin.com/t/openzeppelin-contracts-4-0-beta/5878/5) for more info.

What this means is that is we should now change our `import "@openzeppelin/contracts/token/ERC721/ERC721.sol";` to `import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol"`. `ERC721URIStorage.sol` inherits from `ERC721.sol`, so the entire ERC721 standard and all its functionality will still be retained, don't worry. Then, you also want to change your `contract MyNFT is ERC721, Ownable` to `contract MyNFT is ERC721URIStorage, Ownable` to specify the new object you're inheriting from.

In addition, you want to switch your Solidity version under `module.exports` in `hardhat.config.js` from `solidity: "0.7.3",` to `solidity: "0.8.1",`. The reason it's 0.8.1, not 0.8.0, is because the file `"@openzeppelin/contracts/utils/Address.sol"` uses `pragma solidity ^0.8.1;` instead of `pragma solidity ^0.8.0;`. I have no clue why, since everything else in their library uses 0.8.0 — must be a bug or inconsistency. I actually ran into this compiler error myself earlier — now, when you run with this new Hardhat configuration, it will first download the 0.8.1 compiler, then compile your code successfully.

Side note — you can remove the `public` keyword from `constructor() public ERC721("peppermintTestNFT", "PMINT") {}`. Constructors are run only once — when the contract is initially deployed. They can't be called at a later time, so aren't "visible" in the sense that variables or functions are. Thus, you don't need to specify the function as public since it can't be called again.

All in all, your new smart contract code should look like this:

```java
//Contract based on https://docs.openzeppelin.com/contracts/3.x/erc721
// SPDX-License-Identifier: MIT
pragma solidity ^0.8.0;

import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
import "@openzeppelin/contracts/utils/Counters.sol";
import "@openzeppelin/contracts/access/Ownable.sol";


contract MyNFT is ERC721URIStorage, Ownable {
    using Counters for Counters.Counter;
    Counters.Counter private _tokenIds;

    constructor() ERC721("MyNFT", "NFT") {}

    function mintNFT(address recipient, string memory tokenURI)
        public onlyOwner
        returns (uint256)
    {
        _tokenIds.increment();

        uint256 newItemId = _tokenIds.current();
        _mint(recipient, newItemId);
        _setTokenURI(newItemId, tokenURI);

        return newItemId;
    }
}
```

Your new `hardhat.config.js` should look like this:

```javascript
/**
* @type import('hardhat/config').HardhatUserConfig
*/
require('dotenv').config();
require("@nomiclabs/hardhat-ethers");
const { API_URL, PRIVATE_KEY } = process.env;
module.exports = {
   solidity: "0.8.1",
   defaultNetwork: "ropsten",
   networks: {
      hardhat: {},
      ropsten: {
         url: API_URL,
         accounts: [`0x${PRIVATE_KEY}`]
      }
   },
}
```