### PR TITLE
Update sending-txs.md

### DIFF
--- a/tutorials/sending-txs.md
+++ b/tutorials/sending-txs.md
@@ -130,7 +130,7 @@ async function main() {
      'to': '0x31B98D14007bDEe637298086988A0bBd31184523', // faucet address to return eth
      'value': 100,
      'gas': 30000,
-     'maxFeePerGas': 1000000108,
+     'maxPriorityFeePerGas': 1000000108,
      'nonce': nonce,
      // optional data field to send message or execute smart contract
     };


### PR DESCRIPTION
It seems that the default value of maxPriorityFeePerGas was changed from 1.0 gwei to 2.5 gwei due to some incentive mechanism for miners.

https://stackoverflow.com/questions/70859510/alchemy-error-what-is-the-meaning-of-this-maxfeepergas-cannot-be-less-than-m